### PR TITLE
clean up atlas functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
 
+    - name: Download atlas
+      run: |
+        python -c "from brainglobe_atlasapi import BrainGlobeAtlas; BrainGlobeAtlas('allen_mouse_25um', check_latest=False)"
+
     - name: Run tests
       run: |
         python -m unittest discover -s tests -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Download atlas
       run: |
-        python -c "from brainglobe_atlasapi import BrainGlobeAtlas; BrainGlobeAtlas('allen_mouse_25um', check_latest=False)"
+        brainglobe install -a allen_mouse_25um
 
     - name: Run tests
       run: |

--- a/PyNutil/__init__.py
+++ b/PyNutil/__init__.py
@@ -1,7 +1,7 @@
 from .results import AtlasData, ExtractionResult, PointSetResult
 from .processing.adapters.base import RegistrationData
 from .processing.adapters import read_alignment
-from .io.atlas_loader import load_atlas_data, load_custom_atlas
+from .io.atlas_loader import load_custom_atlas
 from .processing.pipeline.batch_processor import (
     seg_to_coords,
     image_to_coords,
@@ -18,7 +18,6 @@ __all__ = [
     "PointSetResult",
     "RegistrationData",
     "read_alignment",
-    "load_atlas_data",
     "load_custom_atlas",
     "seg_to_coords",
     "image_to_coords",

--- a/PyNutil/io/atlas_loader.py
+++ b/PyNutil/io/atlas_loader.py
@@ -69,29 +69,6 @@ def resolve_atlas_labels(atlas_labels):
     )
 
 
-@lru_cache(maxsize=8)
-def load_atlas_data(atlas_name):
-    """
-    Loads atlas data using the brainglobe_atlasapi.
-
-    Parameters
-    ----------
-    atlas_name : str
-        Name of the atlas to load.
-
-    Returns
-    -------
-    AtlasData
-        Bundle containing atlas volume, hemisphere map, and labels.
-    """
-    atlas = brainglobe_atlasapi.BrainGlobeAtlas(atlas_name=atlas_name)
-    atlas_labels = load_atlas_labels(atlas)
-    atlas_volume = process_atlas_volume(atlas.annotation)
-    hemi_map = process_atlas_volume(atlas.hemispheres)
-    print("atlas labels loaded ✅")
-    return AtlasData(volume=atlas_volume, hemi_map=hemi_map, labels=atlas_labels)
-
-
 def process_atlas_volume(vol):
     """
     Processes the atlas volume by transposing and reversing axes.

--- a/PyNutil/io/atlas_loader.py
+++ b/PyNutil/io/atlas_loader.py
@@ -1,4 +1,4 @@
-import brainglobe_atlasapi
+from brainglobe_atlasapi import BrainGlobeAtlas
 import pandas as pd
 import numpy as np
 import nrrd
@@ -9,7 +9,7 @@ from ..results import AtlasData
 
 def load_atlas_labels(atlas=None, atlas_name=None):
     if atlas_name:
-        atlas = brainglobe_atlasapi.BrainGlobeAtlas(atlas_name=atlas_name)
+        atlas = BrainGlobeAtlas(atlas_name=atlas_name)
     if not atlas_name and not atlas:
         raise Exception("Either atlas or atlas name must be specified")
     atlas_structures = {

--- a/PyNutil/io/atlas_loader.py
+++ b/PyNutil/io/atlas_loader.py
@@ -48,7 +48,9 @@ def resolve_atlas(atlas):
     volume = process_atlas_volume(atlas.annotation)
     hemi_map = process_atlas_volume(atlas.hemispheres)
     labels = load_atlas_labels(atlas)
-    return AtlasData(volume=volume, hemi_map=hemi_map, labels=labels)
+    resolution = getattr(atlas, "resolution", None)
+    voxel_size_um = float(resolution[0]) if resolution is not None else None
+    return AtlasData(volume=volume, hemi_map=hemi_map, labels=labels, voxel_size_um=voxel_size_um)
 
 
 def resolve_atlas_labels(atlas_labels):

--- a/PyNutil/processing/adapters/anchoring.py
+++ b/PyNutil/processing/adapters/anchoring.py
@@ -11,7 +11,7 @@ import re
 from typing import List
 
 import numpy as np
-
+from brainglobe_atlasapi import BrainGlobeAtlas
 from .base import AnchoringLoader, RegistrationData, SliceInfo, calculate_physical_dimensions
 from ...io.loaders import number_sections, load_json_file
 
@@ -121,9 +121,7 @@ class BrainGlobeRegistrationLoader(AnchoringLoader):
     @staticmethod
     def _get_atlas_shape(atlas_name: str):
         """Return the native (un-reoriented) atlas annotation shape."""
-        import brainglobe_atlasapi
-
-        bg = brainglobe_atlasapi.BrainGlobeAtlas(atlas_name=atlas_name)
+        bg = BrainGlobeAtlas(atlas_name=atlas_name)
         return bg.annotation.shape  # (AP, DV, LR)
 
     @staticmethod

--- a/PyNutil/processing/section_volume.py
+++ b/PyNutil/processing/section_volume.py
@@ -426,22 +426,17 @@ def interpolate_volume(
         Supported *value_mode* values: ``"pixel_count"``, ``"mean"``, ``"object_count"``.
 
         Atlas input:
-                - Pass *atlas* (BrainGlobe atlas or PyNutil AtlasData). Volume and
-                    shape are inferred from ``atlas.annotation`` or ``atlas.volume``.
+                - Pass *atlas* (BrainGlobe atlas or PyNutil AtlasData). The atlas
+                    is resolved to internal (lpi) orientation via ``resolve_atlas``.
     """
     if value_mode not in {"pixel_count", "mean", "object_count"}:
         raise ValueError(
             "value_mode must be one of 'pixel_count', 'mean', or 'object_count'"
         )
 
-    if hasattr(atlas, "annotation") and getattr(atlas, "annotation") is not None:
-        atlas_volume = getattr(atlas, "annotation")
-    elif hasattr(atlas, "volume") and getattr(atlas, "volume") is not None:
-        atlas_volume = getattr(atlas, "volume")
-    else:
-        raise ValueError(
-            "atlas must provide a non-None 'annotation' or 'volume' attribute"
-        )
+    from ..io.atlas_loader import resolve_atlas
+    atlas_data = resolve_atlas(atlas)
+    atlas_volume = atlas_data.volume
 
     out_base_shape = tuple(int(x) for x in atlas_volume.shape)
 

--- a/gui/workers.py
+++ b/gui/workers.py
@@ -5,7 +5,6 @@ import brainglobe_atlasapi
 from PyQt6.QtCore import QThread, pyqtSignal
 from log_manager import TextRedirector
 from PyNutil import (
-    load_atlas_data,
     load_custom_atlas,
     read_alignment,
     seg_to_coords,
@@ -15,6 +14,7 @@ from PyNutil import (
     interpolate_volume,
     save_volume_niftis,
 )
+from PyNutil.io.atlas_loader import resolve_atlas
 
 
 class AnalysisWorker(QThread):
@@ -48,7 +48,7 @@ class AnalysisWorker(QThread):
                 )
             else:
                 print(f"Using BrainGlobe atlas: {self.arguments['atlas_name']}")
-                atlas = load_atlas_data(self.arguments["atlas_name"])
+                atlas = resolve_atlas(brainglobe_atlasapi.BrainGlobeAtlas(self.arguments["atlas_name"]))
 
             if self.cancelled:
                 print("Analysis cancelled")

--- a/gui/workers.py
+++ b/gui/workers.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Any, Dict
 
-import brainglobe_atlasapi
+import from brainglobe_atlasapi import BrainGlobeAtlas
 from PyQt6.QtCore import QThread, pyqtSignal
 from log_manager import TextRedirector
 from PyNutil import (
@@ -48,7 +48,7 @@ class AnalysisWorker(QThread):
                 )
             else:
                 print(f"Using BrainGlobe atlas: {self.arguments['atlas_name']}")
-                atlas = resolve_atlas(brainglobe_atlasapi.BrainGlobeAtlas(self.arguments["atlas_name"]))
+                atlas = resolve_atlas(BrainGlobeAtlas(self.arguments["atlas_name"]))
 
             if self.cancelled:
                 print("Analysis cancelled")
@@ -164,7 +164,7 @@ class AtlasInstallWorker(QThread):
 
         try:
             self.progress_signal.emit(f"Starting installation of {self.atlas_name}...")
-            brainglobe_atlasapi.bg_atlas.BrainGlobeAtlas(self.atlas_name)
+            BrainGlobeAtlas(self.atlas_name)
 
             if self.cancelled:
                 self.finished_signal.emit(

--- a/tests/core/test_brainglobe_registration.py
+++ b/tests/core/test_brainglobe_registration.py
@@ -17,6 +17,7 @@ import unittest
 import cv2
 import numpy as np
 import tifffile
+from brainglobe_atlasapi import BrainGlobeAtlas
 
 TEST_DIR = os.path.dirname(os.path.dirname(__file__))
 BG_DATA = os.path.join(TEST_DIR, "test_data", "brainglobe_registration")
@@ -57,13 +58,13 @@ class TestBrainGlobeRegistration(unittest.TestCase):
         nonzero coverage (brain regions)."""
         from PyNutil.processing.adapters.anchoring import BrainGlobeRegistrationLoader
         from PyNutil.processing.atlas_map import generate_target_slice
-        from PyNutil.io.atlas_loader import load_atlas_data
+        from PyNutil.io.atlas_loader import resolve_atlas
 
         loader = BrainGlobeRegistrationLoader()
         data = loader.load(BG_JSON)
         s = data.slices[0]
 
-        atlas_volume = load_atlas_data("allen_mouse_25um").volume
+        atlas_volume = resolve_atlas(BrainGlobeAtlas("allen_mouse_25um")).volume
         atlas_slice = generate_target_slice(s.anchoring, atlas_volume)
 
         self.assertEqual(atlas_slice.shape, (s.height, s.width))
@@ -77,7 +78,7 @@ class TestBrainGlobeRegistration(unittest.TestCase):
         from PyNutil.processing.adapters.anchoring import BrainGlobeRegistrationLoader
         from PyNutil.processing.adapters.deformation import BrainGlobeDeformationProvider
         from PyNutil.processing.atlas_map import generate_target_slice, warp_image
-        from PyNutil.io.atlas_loader import load_atlas_data
+        from PyNutil.io.atlas_loader import resolve_atlas
 
         loader = BrainGlobeRegistrationLoader()
         data = loader.load(BG_JSON)
@@ -89,7 +90,7 @@ class TestBrainGlobeRegistration(unittest.TestCase):
         self.assertIsNotNone(s.deformation)
         self.assertIsNotNone(s.forward_deformation)
 
-        atlas_volume = load_atlas_data("allen_mouse_25um").volume
+        atlas_volume = resolve_atlas(BrainGlobeAtlas("allen_mouse_25um")).volume
         atlas_slice = generate_target_slice(s.anchoring, atlas_volume).astype(np.float64)
         warped = warp_image(atlas_slice, s.deformation, (s.width, s.height)).astype(np.uint32)
 

--- a/tests/core/test_create_visualisations.py
+++ b/tests/core/test_create_visualisations.py
@@ -20,6 +20,7 @@ import unittest
 import cv2
 import numpy as np
 import pandas as pd
+from brainglobe_atlasapi import BrainGlobeAtlas
 
 
 TEST_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -34,7 +35,7 @@ class TestCreateVisualisationsAdapter(unittest.TestCase):
         by calling _create_visualisations directly."""
         from PyNutil.io.section_visualisation import create_section_visualisations
         from PyNutil.processing.adapters.registry import read_alignment
-        from PyNutil.io.atlas_loader import load_atlas_data
+        from PyNutil.io.atlas_loader import resolve_atlas
 
         alignment_json = os.path.join(
             TEST_DIR, "test_data", "nonlinear_allen_mouse", "alignment.json"
@@ -45,7 +46,7 @@ class TestCreateVisualisationsAdapter(unittest.TestCase):
         if not os.path.isfile(alignment_json):
             self.skipTest("QuickNII alignment test data not found")
 
-        _atlas = load_atlas_data("allen_mouse_25um")
+        _atlas = resolve_atlas(BrainGlobeAtlas("allen_mouse_25um"))
         atlas_volume, atlas_labels = _atlas.volume, _atlas.labels
         reg_data = read_alignment(
             alignment_json, apply_deformation=False, apply_damage=False
@@ -69,7 +70,7 @@ class TestCreateVisualisationsAdapter(unittest.TestCase):
         (without segmentation overlay, since no matching segmentations exist)."""
         from PyNutil.io.section_visualisation import create_section_visualisations
         from PyNutil.processing.adapters.registry import read_alignment
-        from PyNutil.io.atlas_loader import load_atlas_data
+        from PyNutil.io.atlas_loader import resolve_atlas
 
         bg_json = os.path.join(
             TEST_DIR, "test_data", "brainglobe_registration", "brainglobe-registration.json"
@@ -77,7 +78,7 @@ class TestCreateVisualisationsAdapter(unittest.TestCase):
         if not os.path.isfile(bg_json):
             self.skipTest("Brainglobe registration test data not found")
 
-        _atlas = load_atlas_data("allen_mouse_25um")
+        _atlas = resolve_atlas(BrainGlobeAtlas("allen_mouse_25um"))
         atlas_volume, atlas_labels = _atlas.volume, _atlas.labels
         reg_data = read_alignment(
             bg_json, apply_deformation=False, apply_damage=False
@@ -107,9 +108,9 @@ class TestCreateVisualisationsAdapter(unittest.TestCase):
         if not os.path.isfile(bg_json) or not os.path.isfile(coord_file):
             self.skipTest("Brainglobe coordinate test data not found")
 
-        from PyNutil import load_atlas_data, read_alignment, xy_to_coords, quantify_coords, save_analysis
+        from PyNutil import read_alignment, xy_to_coords, quantify_coords, save_analysis
 
-        atlas = load_atlas_data("allen_mouse_25um")
+        atlas = BrainGlobeAtlas("allen_mouse_25um")
         alignment = read_alignment(bg_json)
         result = xy_to_coords(coord_file, alignment, atlas)
         label_df = quantify_coords(result, atlas)
@@ -129,10 +130,10 @@ class TestCreateSectionVisualisationsNoneFolder(unittest.TestCase):
     def test_none_segmentation_folder(self):
         """Passing None as segmentation_folder should not raise."""
         from PyNutil.io.section_visualisation import create_section_visualisations
-        from PyNutil.io.atlas_loader import load_atlas_data
+        from PyNutil.io.atlas_loader import resolve_atlas
         from PyNutil.processing.adapters.base import SliceInfo
 
-        _atlas = load_atlas_data("allen_mouse_25um")
+        _atlas = resolve_atlas(BrainGlobeAtlas("allen_mouse_25um"))
         atlas_volume, atlas_labels = _atlas.volume, _atlas.labels
 
         slices = [
@@ -161,9 +162,9 @@ class TestCreateSectionVisualisationsNoneFolder(unittest.TestCase):
     def test_empty_slices_list(self):
         """An empty slices list should produce no output and not raise."""
         from PyNutil.io.section_visualisation import create_section_visualisations
-        from PyNutil.io.atlas_loader import load_atlas_data
+        from PyNutil.io.atlas_loader import resolve_atlas
 
-        _atlas = load_atlas_data("allen_mouse_25um")
+        _atlas = resolve_atlas(BrainGlobeAtlas("allen_mouse_25um"))
         atlas_volume, atlas_labels = _atlas.volume, _atlas.labels
 
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/core/test_interpolate_volume_value_modes.py
+++ b/tests/core/test_interpolate_volume_value_modes.py
@@ -5,8 +5,9 @@ import tempfile
 import unittest
 
 import numpy as np
+from brainglobe_atlasapi import BrainGlobeAtlas
 
-from PyNutil import load_atlas_data, read_alignment, seg_to_coords, quantify_coords, save_analysis, interpolate_volume
+from PyNutil import read_alignment, seg_to_coords, quantify_coords, save_analysis, interpolate_volume
 from tests.test_helpers import copy_tree_to_demo, small_volume_scale
 
 try:
@@ -34,7 +35,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
 
     def _run_pipeline(self):
         settings = self._load_settings()
-        atlas = load_atlas_data(settings["atlas_name"])
+        atlas = BrainGlobeAtlas(settings["atlas_name"])
         alignment = read_alignment(settings["alignment_json"])
         result = seg_to_coords(
             settings["segmentation_folder"],
@@ -178,7 +179,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
 
     def test_colour_auto_matches_adapter_auto_detection(self):
         settings = self._load_settings()
-        atlas = load_atlas_data(settings["atlas_name"])
+        atlas = BrainGlobeAtlas(settings["atlas_name"])
         scale = self._scale_for_small_volume(atlas.volume.shape)
 
         common_kwargs = dict(

--- a/tests/core/test_interpolate_volume_value_modes.py
+++ b/tests/core/test_interpolate_volume_value_modes.py
@@ -8,6 +8,7 @@ import numpy as np
 from brainglobe_atlasapi import BrainGlobeAtlas
 
 from PyNutil import read_alignment, seg_to_coords, quantify_coords, save_analysis, interpolate_volume
+from PyNutil.io.atlas_loader import resolve_atlas
 from tests.test_helpers import copy_tree_to_demo, small_volume_scale
 
 try:
@@ -52,7 +53,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
     def test_value_mode_mean_matches_pixel_count_over_frequency(self):
         settings, atlas, result, label_df = self._run_pipeline()
 
-        scale = self._scale_for_small_volume(atlas.annotation.shape)
+        scale = self._scale_for_small_volume(resolve_atlas(atlas).volume.shape)
 
         common_kwargs = dict(
             segmentation_folder=settings["segmentation_folder"],
@@ -116,7 +117,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
     def test_value_mode_object_count_basic_invariants(self):
         settings, atlas, result, label_df = self._run_pipeline()
 
-        scale = self._scale_for_small_volume(atlas.annotation.shape)
+        scale = self._scale_for_small_volume(resolve_atlas(atlas).volume.shape)
 
         common_kwargs = dict(
             segmentation_folder=settings["segmentation_folder"],
@@ -180,7 +181,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
     def test_colour_auto_matches_adapter_auto_detection(self):
         settings = self._load_settings()
         atlas = BrainGlobeAtlas(settings["atlas_name"])
-        scale = self._scale_for_small_volume(atlas.annotation.shape)
+        scale = self._scale_for_small_volume(resolve_atlas(atlas).volume.shape)
 
         common_kwargs = dict(
             segmentation_folder=settings["segmentation_folder"],

--- a/tests/core/test_interpolate_volume_value_modes.py
+++ b/tests/core/test_interpolate_volume_value_modes.py
@@ -52,7 +52,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
     def test_value_mode_mean_matches_pixel_count_over_frequency(self):
         settings, atlas, result, label_df = self._run_pipeline()
 
-        scale = self._scale_for_small_volume(atlas.volume.shape)
+        scale = self._scale_for_small_volume(atlas.annotation.shape)
 
         common_kwargs = dict(
             segmentation_folder=settings["segmentation_folder"],
@@ -116,7 +116,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
     def test_value_mode_object_count_basic_invariants(self):
         settings, atlas, result, label_df = self._run_pipeline()
 
-        scale = self._scale_for_small_volume(atlas.volume.shape)
+        scale = self._scale_for_small_volume(atlas.annotation.shape)
 
         common_kwargs = dict(
             segmentation_folder=settings["segmentation_folder"],
@@ -180,7 +180,7 @@ class TestInterpolateVolumeValueModes(TimedTestCase):
     def test_colour_auto_matches_adapter_auto_detection(self):
         settings = self._load_settings()
         atlas = BrainGlobeAtlas(settings["atlas_name"])
-        scale = self._scale_for_small_volume(atlas.volume.shape)
+        scale = self._scale_for_small_volume(atlas.annotation.shape)
 
         common_kwargs = dict(
             segmentation_folder=settings["segmentation_folder"],

--- a/tests/core/test_return_orientation.py
+++ b/tests/core/test_return_orientation.py
@@ -5,7 +5,9 @@ import unittest
 
 import numpy as np
 
-from PyNutil import seg_to_coords, read_alignment, load_atlas_data
+from brainglobe_atlasapi import BrainGlobeAtlas
+
+from PyNutil import seg_to_coords, read_alignment
 
 
 TEST_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -26,7 +28,7 @@ class TestReturnOrientation(unittest.TestCase):
         if not os.path.isfile(alignment_json):
             raise unittest.SkipTest("Test data not found")
 
-        cls.atlas = load_atlas_data("allen_mouse_25um")
+        cls.atlas = BrainGlobeAtlas("allen_mouse_25um")
         cls.alignment = read_alignment(alignment_json)
         cls.seg_folder = seg_folder
 

--- a/tests/regression/test_build_volume_from_sections.py
+++ b/tests/regression/test_build_volume_from_sections.py
@@ -44,7 +44,7 @@ class TestBuildVolumeFromSections(TimedTestCase):
         atlas, result, label_df, alignment = run_pipeline_from_settings(settings)
 
         # Downscale to keep runtime/memory small and stable.
-        scale = small_volume_scale(atlas.volume.shape)
+        scale = small_volume_scale(atlas.annotation.shape)
 
         # Plane-based volume: every pixel in each section plane contributes
         # (0 for background, 1 for segmentation colour), and fv counts coverage.

--- a/tests/regression/test_build_volume_from_sections.py
+++ b/tests/regression/test_build_volume_from_sections.py
@@ -44,7 +44,8 @@ class TestBuildVolumeFromSections(TimedTestCase):
         atlas, result, label_df, alignment = run_pipeline_from_settings(settings)
 
         # Downscale to keep runtime/memory small and stable.
-        scale = small_volume_scale(atlas.annotation.shape)
+        from PyNutil.io.atlas_loader import resolve_atlas
+        scale = small_volume_scale(resolve_atlas(atlas).volume.shape)
 
         # Plane-based volume: every pixel in each section plane contributes
         # (0 for background, 1 for segmentation colour), and fv counts coverage.

--- a/tests/regression/test_damage_volume_interpolation.py
+++ b/tests/regression/test_damage_volume_interpolation.py
@@ -23,7 +23,7 @@ class TestDamageVolumeInterpolation(TimedTestCase):
 
     def _run_interpolation(self, do_interpolation=False, non_linear=False, k=5):
         atlas, result, label_df, alignment = run_pipeline_from_settings_file(self.settings_path)
-        scale = small_volume_scale(atlas.volume.shape)
+        scale = small_volume_scale(atlas.annotation.shape)
 
         gv, fv, dv = interpolate_volume(
             segmentation_folder=self.settings["segmentation_folder"],
@@ -101,7 +101,7 @@ class TestDamageVolumeInterpolation(TimedTestCase):
                 interpolated_volume=gv,
                 frequency_volume=fv,
                 damage_volume=dv,
-                atlas_volume=atlas.volume,
+                atlas_volume=atlas.annotation,
                 voxel_size_um=atlas.voxel_size_um or 25.0,
             )
 

--- a/tests/regression/test_damage_volume_interpolation.py
+++ b/tests/regression/test_damage_volume_interpolation.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import numpy as np
 from PyNutil import interpolate_volume, save_analysis
+from PyNutil.io.atlas_loader import resolve_atlas
 from tests.test_helpers import run_pipeline_from_settings_file, small_volume_scale, load_atlas_from_settings
 
 try:
@@ -23,7 +24,7 @@ class TestDamageVolumeInterpolation(TimedTestCase):
 
     def _run_interpolation(self, do_interpolation=False, non_linear=False, k=5):
         atlas, result, label_df, alignment = run_pipeline_from_settings_file(self.settings_path)
-        scale = small_volume_scale(atlas.annotation.shape)
+        scale = small_volume_scale(resolve_atlas(atlas).volume.shape)
 
         gv, fv, dv = interpolate_volume(
             segmentation_folder=self.settings["segmentation_folder"],
@@ -96,13 +97,14 @@ class TestDamageVolumeInterpolation(TimedTestCase):
             # Note: save_analysis does not save volume niftis; the damage volume
             # persistence test needs save_volume_niftis for that.
             from PyNutil import save_volume_niftis
+            atlas_data = resolve_atlas(atlas)
             save_volume_niftis(
                 output_folder=tmpdir,
                 interpolated_volume=gv,
                 frequency_volume=fv,
                 damage_volume=dv,
-                atlas_volume=atlas.annotation,
-                voxel_size_um=atlas.resolution[0],
+                atlas_volume=atlas_data.volume,
+                voxel_size_um=atlas_data.voxel_size_um,
             )
 
             self.assertTrue(os.path.exists(damage_nifti_path), f"Damage volume NIfTI should be saved at {damage_nifti_path}")

--- a/tests/regression/test_damage_volume_interpolation.py
+++ b/tests/regression/test_damage_volume_interpolation.py
@@ -102,7 +102,7 @@ class TestDamageVolumeInterpolation(TimedTestCase):
                 frequency_volume=fv,
                 damage_volume=dv,
                 atlas_volume=atlas.annotation,
-                voxel_size_um=atlas.voxel_size_um or 25.0,
+                voxel_size_um=atlas.resolution[0],
             )
 
             self.assertTrue(os.path.exists(damage_nifti_path), f"Damage volume NIfTI should be saved at {damage_nifti_path}")

--- a/tests/regression/test_intensity_quantification.py
+++ b/tests/regression/test_intensity_quantification.py
@@ -4,11 +4,12 @@ import sys
 import shutil
 import json
 import pandas as pd
+from brainglobe_atlasapi import BrainGlobeAtlas
 
 # Add the root directory to sys.path to allow importing PyNutil
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from PyNutil import load_atlas_data, read_alignment, image_to_coords, quantify_coords, save_analysis
+from PyNutil import read_alignment, image_to_coords, quantify_coords, save_analysis
 from tests.timing_utils import TimedTestCase
 
 class TestIntensityQuantification(TimedTestCase):
@@ -28,7 +29,7 @@ class TestIntensityQuantification(TimedTestCase):
         if os.path.exists(output_folder):
             shutil.rmtree(output_folder)
 
-        atlas = load_atlas_data(self.atlas_name)
+        atlas = BrainGlobeAtlas(self.atlas_name)
         alignment = read_alignment(self.alignment_json)
         result = image_to_coords(
             self.image_folder,
@@ -65,7 +66,7 @@ class TestIntensityQuantification(TimedTestCase):
         if os.path.exists(output_folder):
             shutil.rmtree(output_folder)
 
-        atlas = load_atlas_data(self.atlas_name)
+        atlas = BrainGlobeAtlas(self.atlas_name)
         alignment = read_alignment(self.alignment_json)
         result = image_to_coords(
             self.rgb_image_folder,
@@ -100,7 +101,7 @@ class TestIntensityQuantification(TimedTestCase):
         if os.path.exists(output_folder):
             shutil.rmtree(output_folder)
 
-        atlas = load_atlas_data(self.atlas_name)
+        atlas = BrainGlobeAtlas(self.atlas_name)
         alignment = read_alignment(self.alignment_json)
         result = image_to_coords(
             self.image_folder,

--- a/tests/regression/test_visualisations.py
+++ b/tests/regression/test_visualisations.py
@@ -5,8 +5,9 @@ import unittest
 
 import cv2
 import numpy as np
+from brainglobe_atlasapi import BrainGlobeAtlas
 
-from PyNutil import load_atlas_data, read_alignment, seg_to_coords
+from PyNutil import read_alignment, seg_to_coords
 from timing_utils import TimedTestCase
 
 
@@ -45,7 +46,7 @@ class TestVisualisations(TimedTestCase):
             with open(self.settings_path) as f:
                 settings = json.load(f)
 
-            atlas = load_atlas_data(settings["atlas_name"])
+            atlas = BrainGlobeAtlas(settings["atlas_name"])
             alignment = read_alignment(settings["alignment_json"])
             result = seg_to_coords(
                 settings["segmentation_folder"],

--- a/tests/regression/test_visualisations.py
+++ b/tests/regression/test_visualisations.py
@@ -8,6 +8,7 @@ import numpy as np
 from brainglobe_atlasapi import BrainGlobeAtlas
 
 from PyNutil import read_alignment, seg_to_coords
+from PyNutil.io.atlas_loader import resolve_atlas
 from timing_utils import TimedTestCase
 
 
@@ -46,7 +47,7 @@ class TestVisualisations(TimedTestCase):
             with open(self.settings_path) as f:
                 settings = json.load(f)
 
-            atlas = BrainGlobeAtlas(settings["atlas_name"])
+            atlas = resolve_atlas(BrainGlobeAtlas(settings["atlas_name"]))
             alignment = read_alignment(settings["alignment_json"])
             result = seg_to_coords(
                 settings["segmentation_folder"],
@@ -67,7 +68,7 @@ class TestVisualisations(TimedTestCase):
             create_section_visualisations(
                 settings["segmentation_folder"],
                 reg_data.slices,
-                atlas.annotation,
+                atlas.volume,
                 atlas.labels,
                 output_root,
                 adapter=adapter,

--- a/tests/regression/test_visualisations.py
+++ b/tests/regression/test_visualisations.py
@@ -67,7 +67,7 @@ class TestVisualisations(TimedTestCase):
             create_section_visualisations(
                 settings["segmentation_folder"],
                 reg_data.slices,
-                atlas.volume,
+                atlas.annotation,
                 atlas.labels,
                 output_root,
                 adapter=adapter,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,8 +2,9 @@ import json
 import os
 import shutil
 
+from brainglobe_atlasapi import BrainGlobeAtlas
+
 from PyNutil import (
-    load_atlas_data,
     load_custom_atlas,
     read_alignment,
     seg_to_coords,
@@ -22,7 +23,7 @@ def small_volume_scale(atlas_shape, target_max_dim: float = 80.0) -> float:
 def load_atlas_from_settings(settings: dict):
     """Load an AtlasData from a settings dictionary."""
     if settings.get("atlas_name"):
-        return load_atlas_data(settings["atlas_name"])
+        return BrainGlobeAtlas(settings["atlas_name"])
     return load_custom_atlas(
         settings["atlas_path"],
         settings.get("hemi_path"),


### PR DESCRIPTION
This PR cleans up the way we were interacting with atlases. Previously some functions use "resolve atlas", some used "load_atlas_data" and some directly used the BrainGlobeAtlasApi. Now, everything goes through resolve atlas